### PR TITLE
Enable customization of cocoapods target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
-os: osx
+os:
+  - osx
 
-osx_image: xcode10.1
+osx_image: xcode9.3
 
 language: java
 

--- a/gradle-plugin/src/test/kotlin/com/alecstrong/cocoapods/gradle/plugin/PluginTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/alecstrong/cocoapods/gradle/plugin/PluginTest.kt
@@ -76,6 +76,35 @@ class PluginTest {
   }
 
   @Test
+  fun `run createIosDebugArtifacts without preset`() {
+    val fixtureName = "sample-no-preset"
+    val fixtureRoot = File("src/test/$fixtureName")
+    val runner = GradleRunner.create()
+        .withProjectDir(fixtureRoot)
+        .withPluginClasspath()
+        .forwardOutput()
+
+    val framework = File(fixtureRoot, "build/sample.framework").apply { deleteRecursively() }
+    val dsym = File(fixtureRoot, "build/sample.framework.dSYM").apply { deleteRecursively() }
+
+    runner.withArguments("createIosDebugArtifacts", "--stacktrace", "--info").build()
+
+    assertThat(framework.exists()).isTrue()
+    assertThat(dsym.exists()).isTrue()
+
+    val plist = File(framework, "Info.plist")
+    assertThat(plist.exists()).isTrue()
+
+    assertThat(plist.readText()).apply {
+      contains("iPhoneSimulator")
+      contains("iPhoneOS")
+    }
+
+    framework.deleteRecursively()
+    dsym.deleteRecursively()
+  }
+
+  @Test
   fun `run iosTest`() {
     val fixtureName = "sample"
     val fixtureRoot = File("src/test/$fixtureName")

--- a/gradle-plugin/src/test/sample-no-preset/build.gradle
+++ b/gradle-plugin/src/test/sample-no-preset/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+  id 'org.jetbrains.kotlin.multiplatform'
+  id 'com.alecstrong.cocoapods'
+}
+
+archivesBaseName = 'Sample'
+
+repositories {
+  mavenCentral()
+}
+
+kotlin {
+  sourceSets {
+    commonMain {}
+    iosMain {}
+  }
+
+  targetFromPreset(presets.iosArm64, 'iosDevice') {
+    binaries {
+      framework()
+    }
+  }
+  targetFromPreset(presets.iosX64, 'iosSimulator') {
+    binaries {
+      framework()
+    }
+  }
+  
+  configure([targets.iosDevice, targets.iosSimulator]) {
+    compilations.main.source(sourceSets.iosMain)
+  }
+}

--- a/gradle-plugin/src/test/sample-no-preset/settings.gradle
+++ b/gradle-plugin/src/test/sample-no-preset/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'sample'

--- a/gradle-plugin/src/test/sample-no-preset/src/commonMain/kotlin/com/example/SampleClass.kt
+++ b/gradle-plugin/src/test/sample-no-preset/src/commonMain/kotlin/com/example/SampleClass.kt
@@ -1,0 +1,7 @@
+package com.example
+
+class SampleClass {
+  fun someMethod(): String {
+    return "sup"
+  }
+}

--- a/gradle-plugin/src/test/sample-override-framework/build.gradle
+++ b/gradle-plugin/src/test/sample-override-framework/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+  id 'org.jetbrains.kotlin.multiplatform'
+  id 'com.alecstrong.cocoapods'
+}
+
+archivesBaseName = 'Sample'
+
+repositories {
+  mavenCentral()
+}
+
+kotlin {
+  sourceSets {
+    commonMain {}
+    iosMain {}
+  }
+
+  targetForCocoapods('ios') {
+    binaries {
+      framework()
+    }
+  }
+}

--- a/gradle-plugin/src/test/sample-override-framework/settings.gradle
+++ b/gradle-plugin/src/test/sample-override-framework/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'sample'

--- a/gradle-plugin/src/test/sample-override-framework/src/commonMain/kotlin/com/example/SampleClass.kt
+++ b/gradle-plugin/src/test/sample-override-framework/src/commonMain/kotlin/com/example/SampleClass.kt
@@ -1,0 +1,7 @@
+package com.example
+
+class SampleClass {
+  fun someMethod(): String {
+    return "sup"
+  }
+}

--- a/gradle-plugin/src/test/sample/build.gradle
+++ b/gradle-plugin/src/test/sample/build.gradle
@@ -24,7 +24,5 @@ kotlin {
     iosTest {}
   }
 
-  targets {
-    targetFromPreset(cocoapodsPreset, 'ios')
-  }
+  targetForCocoapods('ios')
 }


### PR DESCRIPTION
Closes #3 

this changes the syntax from:

```
targetFromPreset(cocoapodsPreset, 'ios')
```

to

```
targetForCocoapods('ios')
```

and you can optionally configure:

```
targetForCocoapods('ios') {
  compilations.main.extraOpts '-module-name', 'SC'
}
```