### PR TITLE
re-add arm32 support + don't create a fat dsym for release builds

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/CocoapodsCompileTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/CocoapodsCompileTask.kt
@@ -21,10 +21,14 @@ open class CocoapodsCompileTask : DefaultTask() {
 
   @TaskAction
   fun compileFatDsym() {
-    compileFatBinary(
-        binaryPath = "Contents/Resources/DWARF/${project.name}",
-        bundleName = "${project.name}.framework.dSYM"
-    )
+    // dsyms are not created for release builds, yet
+    // https://github.com/JetBrains/kotlin-native/issues/2422
+    if (buildType != NativeBuildType.RELEASE) {
+      compileFatBinary(
+              binaryPath = "Contents/Resources/DWARF/${project.name}",
+              bundleName = "${project.name}.framework.dSYM"
+      )
+    }
   }
 
   private fun compileFatBinary(

--- a/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/CocoapodsTargetPreset.kt
+++ b/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/CocoapodsTargetPreset.kt
@@ -22,7 +22,9 @@ class CocoapodsTargetPreset(
         extension.presets.getByName("iosX64"), name
     ) as KotlinNativeTarget).configureTarget {
       binaries {
-        framework()
+        framework {
+          embedBitcode("disable")
+        }
       }
     }
 
@@ -33,9 +35,7 @@ class CocoapodsTargetPreset(
               extension.presets.getByName(architecture), architecture
       ) as KotlinNativeTarget).configureTarget {
         binaries {
-          framework {
-            embedBitcode("disable")
-          }
+          framework()
         }
       }
       configureSources(name, target.compilations)

--- a/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/CocoapodsTargetPreset.kt
+++ b/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/CocoapodsTargetPreset.kt
@@ -26,17 +26,20 @@ class CocoapodsTargetPreset(
       }
     }
 
-    val device = (extension.targetFromPreset(
-        extension.presets.getByName("iosArm64"), "${name}Device"
-    ) as KotlinNativeTarget).configureTarget {
-      binaries {
-        framework {
-          embedBitcode("disable")
+    val validArchitectures = listOf("iosArm32", "iosArm64")
+
+    validArchitectures.forEach { architecture ->
+      val target = (extension.targetFromPreset(
+              extension.presets.getByName(architecture), architecture
+      ) as KotlinNativeTarget).configureTarget {
+        binaries {
+          framework {
+            embedBitcode("disable")
+          }
         }
       }
+      configureSources(name, target.compilations)
     }
-
-    configureSources(name, device.compilations)
 
     project.tasks.register("${name}Test", CocoapodsTestTask::class.java) { task ->
       task.dependsOn(simulator.compilations.getByName("test").getLinkTask(EXECUTABLE, DEBUG))

--- a/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/Compatibility.kt
+++ b/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/Compatibility.kt
@@ -11,6 +11,6 @@ internal fun NativeBuildType.name() = when (this) {
 internal fun KonanTarget.architecture() = when (this) {
   is KonanTarget.IOS_X64 -> "x86_64"
   is KonanTarget.IOS_ARM64 -> "arm64"
-  is KonanTarget.IOS_ARM32 -> "arm32"
+  is KonanTarget.IOS_ARM32 -> "armv7"
   else -> throw IllegalStateException("Cannot collapse non-ios target $this into descriptor.")
 }


### PR DESCRIPTION
The `createIosReleaseArtifacts` task was failing because it tried to create a fat dsyms - but dsyms aren't created for release builds (yet).

- reenable compilation for iOS ARM32 / armv7 architecture
- don't try to lipo a fat dsym for release builds due to https://github.com/JetBrains/kotlin-native/issues/2422