### PR TITLE
Fix CFBundleSupportedPlatforms logic

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/CocoapodsCompileTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/CocoapodsCompileTask.kt
@@ -90,26 +90,6 @@ open class CocoapodsCompileTask : DefaultTask() {
         exec.executable = "/usr/libexec/PlistBuddy"
         exec.args = listOf("-c", "Delete :UIRequiredDeviceCapabilities", plistPath)
       }.rethrowFailure().assertNormalExitValue().exitValue
-
-      // Clear supported platforms
-      project.exec { exec ->
-        exec.executable = "/usr/libexec/PlistBuddy"
-        exec.args = listOf("-c", "Delete :CFBundleSupportedPlatforms:0", plistPath)
-      }.rethrowFailure().assertNormalExitValue()
-
-      compilations.map { it.binary.target.konanTarget.supportedPlatform() }.distinct()
-          .forEachIndexed { index, platform ->
-            project.exec { exec ->
-              exec.executable = "/usr/libexec/PlistBuddy"
-              exec.args = listOf("-c", "Add :CFBundleSupportedPlatforms:$index string $platform", plistPath)
-            }.rethrowFailure().assertNormalExitValue()
-          }
     }
-  }
-
-  private fun KonanTarget.supportedPlatform(): String = when (this) {
-    IOS_X64 -> "iPhoneOS"
-    IOS_ARM64, IOS_ARM32 -> "iPhoneSimulator"
-    else -> throw AssertionError()
   }
 }

--- a/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/CocoapodsCompileTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/CocoapodsCompileTask.kt
@@ -90,6 +90,18 @@ open class CocoapodsCompileTask : DefaultTask() {
         exec.executable = "/usr/libexec/PlistBuddy"
         exec.args = listOf("-c", "Delete :UIRequiredDeviceCapabilities", plistPath)
       }.rethrowFailure().assertNormalExitValue().exitValue
+
+      // Clear supported platforms
+      project.exec { exec ->
+        exec.executable = "/usr/libexec/PlistBuddy"
+        exec.args = listOf("-c", "Delete :CFBundleSupportedPlatforms:0", plistPath)
+      }.rethrowFailure().assertNormalExitValue()
+
+      // only add iPhoneOS as supported platform
+      project.exec { exec ->
+        exec.executable = "/usr/libexec/PlistBuddy"
+        exec.args = listOf("-c", "Add :CFBundleSupportedPlatforms:0 string iPhoneOS", plistPath)
+      }.rethrowFailure().assertNormalExitValue()
     }
   }
 }

--- a/gradle-plugin/src/test/kotlin/com/alecstrong/cocoapods/gradle/plugin/PluginTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/alecstrong/cocoapods/gradle/plugin/PluginTest.kt
@@ -67,7 +67,6 @@ class PluginTest {
     assertThat(plist.exists()).isTrue()
 
     assertThat(plist.readText()).apply {
-      contains("iPhoneSimulator")
       contains("iPhoneOS")
     }
 
@@ -96,7 +95,6 @@ class PluginTest {
     assertThat(plist.exists()).isTrue()
 
     assertThat(plist.readText()).apply {
-      contains("iPhoneSimulator")
       contains("iPhoneOS")
       doesNotContain("UIRequiredDeviceCapabilities")
     }


### PR DESCRIPTION
the `iPhoneSimulator` key shouldn't be added to the `CFBundleSupportedPlatforms` array at all - otherwise App Store will complain with the following message:

"Invalid Bundle - Info.plist should specify CFBundleSupportedPlatforms with an array containing a single platform"

So for now only iPhoneOS is being added to `CFBundleSupportedPlatforms`. Builds will still be able to run on simulators.