### PR TITLE
Allow configuration of gradle wrapper used by Podspec through task config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ cocoapods {
   license = "..." // Defaults to empty
   summary = "..." // Defaults to empty
   daemon = true // Defaults to false
+  wrapperExecutableName = "gradlew" // Defaults to "gradlew"
+  wrapperAdditionalArgs = "..." // Defaults to empty
 }
 ```
 

--- a/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/CocoapodsExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/CocoapodsExtension.kt
@@ -7,5 +7,7 @@ open class CocoapodsExtension(
   var authors: String? = null,
   var license: String? = null,
   var summary: String? = null,
-  var daemon: Boolean = false
+  var daemon: Boolean = false,
+  var wrapperExecutableName: String? = null,
+  var wrapperAdditionalArgs: String? = null
 )

--- a/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/CocoapodsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/CocoapodsPlugin.kt
@@ -27,6 +27,8 @@ open class CocoapodsPlugin : Plugin<Project> {
         task.license = extension.license
         task.summary = extension.summary
         task.daemon = extension.daemon
+        task.wrapperExecutableName = extension.wrapperExecutableName
+        task.wrapperAdditionalArgs = extension.wrapperAdditionalArgs
       }
 
       project.tasks.register("initializeFramework", InitializeFrameworkTask::class.java) { task ->

--- a/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/GeneratePodspecTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/GeneratePodspecTask.kt
@@ -16,15 +16,19 @@ open class GeneratePodspecTask : DefaultTask() {
   var license: String? = null
   var summary: String? = null
   var daemon: Boolean = false
+  var wrapperExecutableName: String? = null
+  var wrapperAdditionalArgs: String? = null
 
   @TaskAction
   fun generatePodspec() {
+    val wrapperExecutableName = this.wrapperExecutableName ?: "gradlew"
+    val wrapperAdditionalArgs = wrapperAdditionalArgs ?: ""
     var current = project.projectDir
     var gradlew: String
     if (current == project.rootDir) {
-      gradlew = "./gradlew"
+      gradlew = "./$wrapperExecutableName"
     } else {
-      gradlew = "gradlew"
+      gradlew = wrapperExecutableName
       while (current != project.rootDir) {
         gradlew = "../$gradlew"
         current = current.parentFile
@@ -48,7 +52,7 @@ open class GeneratePodspecTask : DefaultTask() {
       |
       |  spec.prepare_command = <<-SCRIPT
       |    set -ev
-      |    $gradlew ${if (daemon) "" else "--no-daemon" } -P${InitializeFrameworkTask.FRAMEWORK_PROPERTY}=#{spec.name}.framework initializeFramework --stacktrace
+      |    $gradlew ${if (daemon) "" else "--no-daemon" } -P${InitializeFrameworkTask.FRAMEWORK_PROPERTY}=#{spec.name}.framework initializeFramework --stacktrace $wrapperAdditionalArgs
       |  SCRIPT
       |
       |  spec.script_phases = [
@@ -57,7 +61,7 @@ open class GeneratePodspecTask : DefaultTask() {
       |      :shell_path => '/bin/sh',
       |      :script => <<-SCRIPT
       |        set -ev
-      |        ${'$'}PODS_TARGET_SRCROOT/$gradlew ${if (daemon) "" else "--no-daemon" } -p "${'$'}PODS_TARGET_SRCROOT" "createIos${'$'}{CONFIGURATION}Artifacts"
+      |        ${'$'}PODS_TARGET_SRCROOT/$gradlew ${if (daemon) "" else "--no-daemon" } -p "${'$'}PODS_TARGET_SRCROOT" "createIos${'$'}{CONFIGURATION}Artifacts" $wrapperAdditionalArgs
       |      SCRIPT
       |    }
       |  ]


### PR DESCRIPTION
`wrapperExecutableName` is useful for example if you have `gradlew` in a different directory (e.g. `../gradlew`), or in my case I also use a intermediate task that downloads and uses the [Zulu OpenJDK](https://www.azul.com/downloads/zulu/) if no JDK found before passing execution to gradlew.

`wrapperAdditionalArgs` also comes in handy (e.g. for my CI I logs want to add `--console=plain`).