### PR TITLE
Simulator build fix

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/CocoapodsCompileTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/CocoapodsCompileTask.kt
@@ -14,6 +14,7 @@ import java.io.File
 open class CocoapodsCompileTask : DefaultTask() {
   @InputFiles lateinit var inputs: FileCollection
 
+  @Input internal lateinit var buildDeviceArchTarget: Architecture
   @Input internal var buildType: NativeBuildType? = null
     set(value) {
       val outputs = mutableListOf("${project.buildDir.path}/${project.name}.framework")
@@ -58,7 +59,7 @@ open class CocoapodsCompileTask : DefaultTask() {
     binaryPath: String,
     bundleName: String
   ) {
-    logger.debug("Creating fat binary for $binaryPath $bundleName")
+    logger.info("Creating fat binary for $binaryPath $bundleName")
     val finalContainerPath = "${project.buildDir.path}/$bundleName"
     val finalOutputPath =  "$finalContainerPath/$binaryPath"
 
@@ -72,11 +73,12 @@ open class CocoapodsCompileTask : DefaultTask() {
       compilations.forEach { compilation ->
         val output = compilation.outputFile.get().parentFile.absolutePath
         val target = compilation.binary.target.konanTarget
-        if (target.architecture == Architecture.ARM64) {
+        if (target.architecture == buildDeviceArchTarget) {
+          logger.info("Selected device arch target: ${target.architecture}")
           deviceParentDir = output
         }
 
-        logger.debug("Lipo'ing for arch ${target.architecture} with path $output/$bundleName/$binaryPath")
+        logger.info("Lipo'ing for arch ${target.architecture} with path $output/$bundleName/$binaryPath")
         args.addAll(listOf(
             "-arch", target.architecture(), "$output/$bundleName/$binaryPath"
         ))

--- a/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/CocoapodsCompileTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/CocoapodsCompileTask.kt
@@ -1,11 +1,14 @@
 package com.alecstrong.cocoapods.gradle.plugin
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectories
 import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecSpec
+import org.gradle.process.internal.ExecException
 import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 import org.jetbrains.kotlin.gradle.tasks.KotlinNativeLink
 import org.jetbrains.kotlin.konan.target.Architecture
@@ -109,16 +112,16 @@ open class CocoapodsCompileTask : DefaultTask() {
     // clean plist (only works for frameworks)
     val plistPath = "$finalContainerPath/Info.plist"
     if (File(plistPath).exists()) {
-      project.exec { exec ->
+      project.tryExec { exec ->
         exec.executable = "/usr/libexec/PlistBuddy"
         exec.args = listOf("-c", "Delete :UIRequiredDeviceCapabilities", plistPath)
-      }.rethrowFailure().assertNormalExitValue().exitValue
+      }
 
       // Clear supported platforms
-      project.exec { exec ->
+      project.tryExec { exec ->
         exec.executable = "/usr/libexec/PlistBuddy"
         exec.args = listOf("-c", "Delete :CFBundleSupportedPlatforms:0", plistPath)
-      }.rethrowFailure().assertNormalExitValue()
+      }
 
       // only add iPhoneOS as supported platform
       project.exec { exec ->
@@ -126,5 +129,12 @@ open class CocoapodsCompileTask : DefaultTask() {
         exec.args = listOf("-c", "Add :CFBundleSupportedPlatforms:0 string iPhoneOS", plistPath)
       }.rethrowFailure().assertNormalExitValue()
     }
+  }
+
+  private fun Project.tryExec(action: (ExecSpec) -> Unit) = try {
+    exec(action::invoke).exitValue
+  } catch (exc: ExecException) {
+    logger.info("Silent error: ${exc.message}")
+    exc.printStackTrace()
   }
 }

--- a/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/CocoapodsExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/CocoapodsExtension.kt
@@ -1,9 +1,12 @@
 package com.alecstrong.cocoapods.gradle.plugin
 
+import org.jetbrains.kotlin.konan.target.Architecture
+
 open class CocoapodsExtension(
   var version: String = "1.0.0-LOCAL",
-  var homepage: String? = null,
   var deploymentTarget: String = "10.0",
+  var buildDeviceArchTarget: Architecture = Architecture.ARM64,
+  var homepage: String? = null,
   var authors: String? = null,
   var license: String? = null,
   var summary: String? = null,

--- a/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/CocoapodsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/alecstrong/cocoapods/gradle/plugin/CocoapodsPlugin.kt
@@ -49,6 +49,7 @@ open class CocoapodsPlugin : Plugin<Project> {
                 CocoapodsCompileTask::class.java
             ) { task ->
               task.dependsOn(compilations)
+              task.buildDeviceArchTarget = extension.buildDeviceArchTarget
               task.buildType = buildType
               task.compilations = compilations
               task.group = GROUP


### PR DESCRIPTION
• Plugin requires to set target preset to 'iosArm64' in not usual way — just crash the build :(
• Crash cli-call to PlistBuddy if entry in Plist.info not exists trying to delete it.

This pr fixes those errors I've been faced trying to integrate kotlin/native library into iOS app.
Next it would be better to be able to sync preset target for k/n and device arch target for this plugin in one transparent way.